### PR TITLE
Drop Minimal from software list

### DIFF
--- a/control/installation.xml
+++ b/control/installation.xml
@@ -32,7 +32,7 @@ textdomain="control"
                   <try_separate_home config:type="boolean">false</try_separate_home>
                 </partitioning>
                 <software>
-                  <default_patterns>base Minimal xen_server</default_patterns>
+                  <default_patterns>base xen_server</default_patterns>
                   <optional_default_patterns><![CDATA[]]></optional_default_patterns>
                 </software>
               </system_role>

--- a/package/system-role-xen.changes
+++ b/package/system-role-xen.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct  4 22:35:58 UTC 2017 - sflees@suse.de
+
+- Drop Minimal from software list, it doesn't exist anymore and 
+  base pulls in its replacement via dependencies
+- 15.0.1
+
+-------------------------------------------------------------------
 Fri Sep 29 16:12:25 UTC 2017 - knut.anderssen@suse.com
 
 - Initial package (needed for having roles in their own package for

--- a/package/system-role-xen.spec
+++ b/package/system-role-xen.spec
@@ -35,7 +35,7 @@ BuildRequires:  yast2-installation-control >= 4.0.0
 
 Url:            https://github.com/yast/system-role-xen
 AutoReqProv:    off
-Version:        15.0.0
+Version:        15.0.1
 Release:        0
 Summary:        Server Xen role definition
 License:        MIT


### PR DESCRIPTION
 it doesn't exist anymore and base pulls in its replacement via dependencies