### PR TITLE
Revert "Remove partitioning info from description"

### DIFF
--- a/control/installation.xml
+++ b/control/installation.xml
@@ -15,6 +15,7 @@
   </xen_host_role>
   <xen_host_role_description>
     <label>• Bare metal hypervisor and tools
+• Dedicated /var/lib/libvirt partition
 • Disable firewall, kdump services</label>
   </xen_host_role_description>
 </texts>

--- a/package/system-role-xen.changes
+++ b/package/system-role-xen.changes
@@ -1,10 +1,4 @@
 -------------------------------------------------------------------
-Tue Sep 25 14:53:18 UTC 2018 - dgonzalez@suse.com
-
-- Delete partitioning information from description (fate#324713)
-- 15.0.7
-
--------------------------------------------------------------------
 Fri Apr 20 09:57:52 CEST 2018 - aginies@suse.com
 
 - adjust XEN description (FATE#324207)

--- a/package/system-role-xen.spec
+++ b/package/system-role-xen.spec
@@ -35,7 +35,7 @@ BuildRequires:  yast2-installation-control >= 4.0.0
 
 Url:            https://github.com/yast/system-role-xen
 AutoReqProv:    off
-Version:        15.0.7
+Version:        15.0.6
 Release:        0
 Summary:        Server Xen role definition
 License:        MIT


### PR DESCRIPTION
Reverts yast/system-role-xen#10

Because there was a misunderstood and those changes are not wanted.